### PR TITLE
chore: update node in CI

### DIFF
--- a/build/base.yml
+++ b/build/base.yml
@@ -36,13 +36,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.x
+              - 20.x
           - name: MacOS
             nodeVersions:
-              - 16.x
+              - 20.x
           - name: Windows
             nodeVersions:
-              - 16.x
+              - 20.x
 
         testSteps:
           - script: npm ci


### PR DESCRIPTION
My last PR updated @vscode/test-cli which includes a function only available on Node >18 and caused tests on main to fail.

VS Code's extension host is on Node 20, so it should be good to test this library in Node 20 as well.