### PR TITLE
add progress and cancellation token to `render`

### DIFF
--- a/src/base/promptElement.ts
+++ b/src/base/promptElement.ts
@@ -52,7 +52,9 @@ export abstract class PromptElement<P extends BasePromptElementProps = BasePromp
 	 *
 	 * @param state - The state of the prompt element.
 	 * @param sizing - The sizing information for the prompt.
+	 * @param progress - Optionally report progress to the user for long-running state preparation.
+	 * @param token - A cancellation token that can be used to signal cancellation to the prompt element.
 	 * @returns The rendered prompt piece or undefined if the element does not want to render anything.
 	 */
-	abstract render(state: S, sizing: PromptSizing): Promise<PromptPiece | undefined> | PromptPiece | undefined;
+	abstract render(state: S, sizing: PromptSizing, progress?: Progress<ChatResponsePart>, token?: CancellationToken): Promise<PromptPiece | undefined> | PromptPiece | undefined;
 }

--- a/src/base/promptRenderer.ts
+++ b/src/base/promptRenderer.ts
@@ -167,7 +167,7 @@ export class PromptRenderer<P extends BasePromptElementProps> {
 
 			const templates = await Promise.all(promptElements.map(async ({ element, promptElementInstance }, i) => {
 				const elementSizing = elementSizings[i];
-				return await promptElementInstance.render(element.node.getState(), elementSizing)
+				return await promptElementInstance.render(element.node.getState(), elementSizing, progress, token)
 			}));
 
 			// Render


### PR DESCRIPTION
Unless there's a reason they are only on prepare?