### PR TITLE
feat: add Expandable elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0-alpha.5
+
+- **feat:** add `Expandable` elements to the renderer. See the [readme](./README.md#expandable-text) for details.
+
 ## 0.3.0-alpha.4
 
 - **feat:** enhance the `HTMLTracer` to allow consumers to visualize element pruning order

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.3.0-alpha.4",
+	"version": "0.3.0-alpha.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/prompt-tsx",
-			"version": "0.3.0-alpha.4",
+			"version": "0.3.0-alpha.5",
 			"license": "SEE LICENSE IN LICENSE",
 			"devDependencies": {
 				"@microsoft/tiktokenizer": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.3.0-alpha.4",
+	"version": "0.3.0-alpha.5",
 	"description": "Declare LLM prompts with TSX",
 	"main": "./dist/base/index.js",
 	"types": "./dist/base/index.d.ts",

--- a/src/base/promptElements.tsx
+++ b/src/base/promptElements.tsx
@@ -303,3 +303,19 @@ export class Chunk extends PromptElement<BasePromptElementProps> {
 		return <>{this.props.children}</>;
 	}
 }
+
+export interface ExpandableProps extends BasePromptElementProps {
+	value: (sizing: PromptSizing) => string | Promise<string>;
+}
+
+/**
+ * An element that can expand to fill the remaining token budget. Takes
+ * a `value` function that is initially called with the element's token budget,
+ * and may be called multiple times with the new token budget as the prompt
+ * is resized.
+ */
+export class Expandable extends PromptElement<ExpandableProps> {
+	async render(_state: void, sizing: PromptSizing): Promise<PromptPiece> {
+		return <>{await this.props.value(sizing)}</>;
+	}
+}

--- a/src/tracer/index.tsx
+++ b/src/tracer/index.tsx
@@ -114,7 +114,7 @@ const App = () => {
 			</div>
 			<div className="control-description">
 				{activeTab === 'tokens'
-					? <p>Token changes here will prune elements and re-render 'pure' ones, but the entire prompt is not being re-rendered</p>
+					? <p>Token changes here will prune elements and re-render Expandable ones, but the entire prompt is not being re-rendered</p>
 					: <p>Changing the render epoch lets you see the order in which elements are rendered and how the token budget is allocated.</p>}
 				<div className='controls-stats'>
 					<span>Used <Integer value={model.container.tokens} />/<Integer value={model.budget} /> tokens</span>


### PR DESCRIPTION
Expandable can be used like so, providing a callback
which returns a string or a promise to a string:

```tsx
<Expandable value={async sizing => {
  let data = 'hi';
  while (true) {
    const more = getMoreUsefulData();
    if (await sizing.countTokens(data + more) > sizing.tokenBudget) { break }
    data += more;
  }
  }
  return data;
}} />
```

After the prompt is rendered, the renderer sums up the tokens used by
all messages. If there is unused budget, then any `<Expandable />`
elements' values are called again with their `PromptSizing` is increased
by the token excess.

If there are multiple `<Expandable />` elements, then they're re-called
in the order in which they were initially rendered. Because they're
designed to fill up any remaining space, it usually makes sense to have
at most one `<Expandable />` element per prompt.