### PR TITLE
Add `internal` reference

### DIFF
--- a/src/base/jsonTypes.ts
+++ b/src/base/jsonTypes.ts
@@ -55,7 +55,13 @@ export type UriOrLocationJSON = UriComponents | { uri: UriComponents; range: Ran
 export interface PromptReferenceJSON {
 	anchor: UriOrLocationJSON | { variableName: string; value?: UriOrLocationJSON };
 	iconPath?: UriComponents | { id: string } | { light: UriComponents; dark: UriComponents };
-	options?: { status?: { description: string; kind: ChatResponseReferencePartStatusKind } };
+	options?: {
+		status?: { description: string; kind: ChatResponseReferencePartStatusKind };
+		/**
+		 * If true, the reference can be seen by tooling but should not be shown to the user.
+		 */
+		internal?: boolean;
+	};
 }
 
 export interface PromptElementJSON {

--- a/src/base/results.ts
+++ b/src/base/results.ts
@@ -53,6 +53,7 @@ export class PromptReference {
 		readonly iconPath?: Uri | ThemeIcon | { light: Uri; dark: Uri },
 		readonly options?: {
 			status?: { description: string; kind: ChatResponseReferencePartStatusKind };
+			internal?: boolean;
 		}
 	) {}
 


### PR DESCRIPTION
References are needed for various parts of our tooling, such as generating links. However in some cases we don't want to show these references to the user, often because they are already implicitly included

This proposals adding a new `.internal` option on `PromptReference`. When set to true, our UI will not show the reference to the user but the reference will still be accessible to other tooling