### PR TITLE
docs: fix grammar in Chunk utility description

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ In this case, a very long `userQuery` would get pruned from the output first if 
 
 ...would be pruned in the order `B->A->D->C`. If two sibling elements share the same priority, the renderer looks ahead at their direct children and picks whichever one has a child with the lowest priority: if the `SystemMessage` and `UserMessage` in the above example did not declare priorities, the pruning order would be `B->D->A->C`.
 
-Continuous text strings and elements can both be pruned from the tree. If you have a set of elements that you want to either be include all the time or none of the time, you can use the simple `Chunk` utility element:
+Continuous text strings and elements can both be pruned from the tree. If you have a set of elements that you want to either include all the time or none of the time, you can use the simple `Chunk` utility element:
 
 ```html
 <Chunk>


### PR DESCRIPTION
Fixes a grammatical error in the Chunk utility documentation.

Before:
> want to either be include

After:
> want to either include