### PR TITLE
refactor: improve speed of text trimming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dist
 .pnp.*
 
 src/base/htmlTracerSrc.ts
+
+*.cpuprofile

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"mocha": "^10.2.0",
 				"preact": "^10.24.2",
 				"prettier": "^2.8.8",
+				"tinybench": "^3.1.1",
 				"tsx": "^4.19.1",
 				"typescript": "^5.6.2"
 			}
@@ -2499,6 +2500,15 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-3.1.1.tgz",
+			"integrity": "sha512-74pmf47HY/bHqamcCMGris+1AtGGsqTZ3Hc/UK4QvSmRuf/9PIF9753+c8XBh7JfX2r9KeZtVjOYjd6vFpc0qQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/to-regex-range": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.3.0-alpha.19",
+	"version": "0.3.0-alpha.20",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/prompt-tsx",
-			"version": "0.3.0-alpha.19",
+			"version": "0.3.0-alpha.20",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/tiktokenizer": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"watch:base": "tsc --watch --sourceMap --preserveWatchOutput",
 		"test": "vscode-test",
 		"test:unit": "cross-env IS_OUTSIDE_VSCODE=1 mocha --import=tsx -u tdd \"src/base/test/**/*.test.{ts,tsx}\"",
+		"test:bench": "tsx ./src/base/test/renderer.bench.tsx",
 		"prettier": "prettier --list-different --write --cache .",
 		"prepare": "tsx ./build/postinstall.ts"
 	},
@@ -38,6 +39,7 @@
 		"mocha": "^10.2.0",
 		"preact": "^10.24.2",
 		"prettier": "^2.8.8",
+		"tinybench": "^3.1.1",
 		"tsx": "^4.19.1",
 		"typescript": "^5.6.2"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.3.0-alpha.19",
+	"version": "0.3.0-alpha.20",
 	"description": "Declare LLM prompts with TSX",
 	"main": "./dist/base/index.js",
 	"types": "./dist/base/index.d.ts",

--- a/src/base/test/renderer.bench.tsx
+++ b/src/base/test/renderer.bench.tsx
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'fs';
+import { Bench } from 'tinybench';
+import { Cl100KBaseTokenizer } from '../tokenizer/cl100kBaseTokenizer';
+import type * as promptTsx from '..';
+import assert = require('assert');
+
+const comparePathVar = 'PROMPT_TSX_COMPARE_PATH';
+const tsxComparePath =
+	process.env[comparePathVar] ||
+	`${__dirname}/../../../../vscode-copilot/node_modules/@vscode/prompt-tsx`;
+const canCompare = existsSync(tsxComparePath);
+if (!canCompare) {
+	console.error(
+		`$${comparePathVar} was not set / ${tsxComparePath} doesn't exist, so the benchmark will not compare to past behavior`
+	);
+	process.exit(1);
+}
+
+const numberOfRepeats = 1;
+const sampleText = readFileSync(`${__dirname}/renderer.test.tsx`, 'utf-8');
+const sampleTextLines = readFileSync(`${__dirname}/renderer.test.tsx`, 'utf-8').split('\n');
+const tokenizer = new Cl100KBaseTokenizer();
+const bench = new Bench({
+	name: `trim ${tokenizer.tokenLength(sampleText) * numberOfRepeats}->1k tokens`,
+	time: 100,
+});
+
+async function benchTokenizationTrim({
+	PromptRenderer,
+	PromptElement,
+	UserMessage,
+	TextChunk,
+}: typeof promptTsx) {
+	const r = await new PromptRenderer(
+		{ modelMaxPromptTokens: 1000 },
+		class extends PromptElement {
+			render() {
+				return (
+					<>
+						{Array.from({ length: numberOfRepeats }, () => (
+							<UserMessage>
+								{sampleTextLines.map(l => (
+									<TextChunk>{l}</TextChunk>
+								))}
+							</UserMessage>
+						))}
+					</>
+				);
+			}
+		},
+		{},
+		tokenizer
+	).render();
+	assert(r.tokenCount <= 1000);
+	assert(r.tokenCount > 100);
+}
+
+bench.add('current', () => benchTokenizationTrim(require('..')));
+if (canCompare) {
+	const fn = require(tsxComparePath);
+	bench.add('previous', () => benchTokenizationTrim(fn));
+}
+
+bench.run().then(() => {
+	console.log(bench.name);
+	console.table(bench.table());
+});


### PR DESCRIPTION
I added a benchmark for a heavy case of pruning. The changes in this PR
reduce the runtime from ~17 seconds to ~0.2 seconds. There are more
optimizations that can be done, but an ~80x speedup is a good start.

Refs https://github.com/microsoft/vscode-copilot-release/issues/4985