### PR TITLE
docs: fix sendRequest API name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const participant = vscode.chat.createChatParticipant(
 			chatModel
 		);
 
-		const chatRequest = await chatModel.sendChatRequest(messages, {}, token);
+		const chatRequest = await chatModel.sendRequest(messages, {}, token);
 
 		// ... Report stream data to VS Code UI
 	}


### PR DESCRIPTION
Refs https://code.visualstudio.com/api/references/vscode-api#LanguageModelChat.sendRequest