### PR TITLE
feat: add cachepoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.3.0-alpha.22",
+	"version": "0.3.0-alpha.23",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/prompt-tsx",
-			"version": "0.3.0-alpha.22",
+			"version": "0.3.0-alpha.23",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/tiktokenizer": "^1.0.6",

--- a/src/base/htmlTracer.ts
+++ b/src/base/htmlTracer.ts
@@ -20,6 +20,7 @@ import {
 	GenericMaterializedContainer,
 	MaterializedNode,
 	MaterializedChatMessageOpaque,
+	MaterializedChatMessageBreakpoint,
 } from './materialized';
 import { PromptMetadata } from './results';
 import { ITokenizer } from './tokenizer/tokenizer';
@@ -236,7 +237,10 @@ async function serializeMaterialized(
 			value: materialized.src,
 			tokens: await materialized.upperBoundTokenCount(tokenizer),
 		};
-	} else if (materialized instanceof MaterializedChatMessageOpaque) {
+	} else if (
+		materialized instanceof MaterializedChatMessageOpaque ||
+		materialized instanceof MaterializedChatMessageBreakpoint
+	) {
 		// todo: add to visualizer
 		return undefined;
 	} else {

--- a/src/base/output/openaiConvert.ts
+++ b/src/base/output/openaiConvert.ts
@@ -15,11 +15,8 @@ function onlyStringContent(content: Raw.ChatCompletionContentPart[]): string {
 function stringAndImageContent(
 	content: Raw.ChatCompletionContentPart[]
 ): string | OpenAI.ChatCompletionContentPart[] {
-	if (!content.some(part => part.type !== Raw.ChatCompletionContentPartKind.Text)) {
-		return onlyStringContent(content);
-	}
 
-	return content
+	const parts = content
 		.map((part): OpenAI.ChatCompletionContentPart | undefined => {
 			if (part.type === Raw.ChatCompletionContentPartKind.Text) {
 				return {
@@ -39,6 +36,13 @@ function stringAndImageContent(
 			}
 		})
 		.filter(r => !!r);
+
+
+	if (parts.every(part => part.type === 'text')) {
+		return parts.map(p=> (p as OpenAI.ChatCompletionContentPartText).text).join('');
+	}
+
+	return parts;
 }
 
 export function toOpenAiChatMessage(message: Raw.ChatMessage): OpenAI.ChatMessage | undefined {

--- a/src/base/output/rawTypes.ts
+++ b/src/base/output/rawTypes.ts
@@ -68,12 +68,14 @@ export interface UserChatMessage extends BaseChatMessage {
 export type ChatCompletionContentPart =
 	| ChatCompletionContentPartImage
 	| ChatCompletionContentPartText
-	| ChatCompletionContentPartOpaque;
+	| ChatCompletionContentPartOpaque
+	| ChatCompletionContentPartCacheCheckpoint;
 
 export enum ChatCompletionContentPartKind {
 	Image,
 	Text,
 	Opaque,
+	CacheCheckpoint,
 }
 
 /** An image completion */
@@ -81,6 +83,16 @@ export interface ChatCompletionContentPartImage {
 	imageUrl: ImageURLReference;
 	type: ChatCompletionContentPartKind.Image;
 }
+
+
+export interface ChatCompletionContentPartCacheCheckpoint {
+	type: ChatCompletionContentPartKind.CacheCheckpoint;
+	/**
+	 * Optional implementation-specific type of the checkpoint.
+	 */
+	cacheType?: string;
+}
+
 
 export interface ImageURLReference {
 	/**

--- a/src/base/output/rawTypes.ts
+++ b/src/base/output/rawTypes.ts
@@ -69,13 +69,13 @@ export type ChatCompletionContentPart =
 	| ChatCompletionContentPartImage
 	| ChatCompletionContentPartText
 	| ChatCompletionContentPartOpaque
-	| ChatCompletionContentPartCacheCheckpoint;
+	| ChatCompletionContentPartCacheBreakpoint;
 
 export enum ChatCompletionContentPartKind {
 	Image,
 	Text,
 	Opaque,
-	CacheCheckpoint,
+	CacheBreakpoint,
 }
 
 /** An image completion */
@@ -84,15 +84,13 @@ export interface ChatCompletionContentPartImage {
 	type: ChatCompletionContentPartKind.Image;
 }
 
-
-export interface ChatCompletionContentPartCacheCheckpoint {
-	type: ChatCompletionContentPartKind.CacheCheckpoint;
+export interface ChatCompletionContentPartCacheBreakpoint {
+	type: ChatCompletionContentPartKind.CacheBreakpoint;
 	/**
-	 * Optional implementation-specific type of the checkpoint.
+	 * Optional implementation-specific type of the breakpoint.
 	 */
 	cacheType?: string;
 }
-
 
 export interface ImageURLReference {
 	/**

--- a/src/base/promptRenderer.ts
+++ b/src/base/promptRenderer.ts
@@ -10,6 +10,7 @@ import {
 	GenericMaterializedContainer,
 	LineBreakBefore,
 	MaterializedChatMessage,
+	MaterializedChatMessageCheckpoint,
 	MaterializedChatMessageImage,
 	MaterializedChatMessageTextChunk,
 } from './materialized';
@@ -32,7 +33,7 @@ import {
 	TokenLimit,
 	TokenLimitProps,
 	ToolMessage,
-	useKeepWith
+	useKeepWith,
 } from './promptElements';
 import { PromptMetadata, PromptReference } from './results';
 import { ITokenizer } from './tokenizer/tokenizer';
@@ -475,13 +476,14 @@ export class PromptRenderer<P extends BasePromptElementProps> {
 			// need a single iteration of this.<sup>[citation needed]</sup>
 			let tokenCount = await container.tokenCount(this._tokenizer);
 			while (tokenCount > limit.limit) {
-				while (tokenCount > limit.limit) {
+				const overhead = await container.baseMessageTokenCount(this._tokenizer);
+				do {
 					for (const node of container.removeLowestPriorityChild()) {
 						removed++;
 						const rmCount = node.upperBoundTokenCount(this._tokenizer);
 						tokenCount -= typeof rmCount === 'number' ? rmCount : await rmCount;
 					}
-				}
+				} while (tokenCount - overhead > limit.limit);
 				tokenCount = await container.tokenCount(this._tokenizer);
 			}
 		}
@@ -614,8 +616,23 @@ export class PromptRenderer<P extends BasePromptElementProps> {
 				return this._handleIntrinsicIgnoredFiles(node, props, children);
 			case 'elementJSON':
 				return this._handleIntrinsicElementJSON(node, props.data);
+			case 'cacheCheckpoint':
+				return this._handleIntrinsicCacheCheckpoint(node, props, children, sortIndex);
 		}
 		throw new Error(`Unknown intrinsic element ${name}!`);
+	}
+
+	private _handleIntrinsicCacheCheckpoint(
+		node: PromptTreeElement,
+		props: any,
+		children: ProcessedPromptPiece[],
+		sortIndex?: number
+	) {
+		if (children.length > 0) {
+			throw new Error(`<cacheCheckpoint /> must not have children!`);
+		}
+
+		node.addCacheCheckpoint(props, sortIndex);
 	}
 
 	private _handleIntrinsicMeta(
@@ -846,7 +863,7 @@ type ProcessedPromptPiece =
 	| IntrinsicPromptPiece<any>
 	| ExtrinsicPromptPiece<any, any>;
 
-type PromptNode = PromptTreeElement | PromptText;
+type PromptNode = PromptTreeElement | PromptText | PromptCacheCheckpoint;
 type LeafPromptNode = PromptText;
 
 /**
@@ -999,7 +1016,8 @@ class PromptTreeElement {
 			children: this._children
 				.slice()
 				.sort((a, b) => a.childIndex - b.childIndex)
-				.map(c => c.toJSON()),
+				.map(c => c.toJSON())
+				.filter(isDefined),
 			props: {},
 			references: this._metadata
 				.filter(m => m instanceof ReferenceMetadata)
@@ -1093,6 +1111,19 @@ class PromptTreeElement {
 		this._metadata.push(metadata);
 	}
 
+	public addCacheCheckpoint(checkpoint: { type: string }, sortIndex = this._children.length): void {
+		if (!(this._obj instanceof BaseChatMessage)) {
+			throw new Error('Cache checkpoints may only be direct children of chat messages');
+		}
+
+		this._children.push(
+			new PromptCacheCheckpoint(
+				{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: checkpoint.type },
+				sortIndex
+			)
+		);
+	}
+
 	public *elements(): Iterable<PromptTreeElement> {
 		yield this;
 		for (const child of this._children) {
@@ -1100,6 +1131,21 @@ class PromptTreeElement {
 				yield* child.elements();
 			}
 		}
+	}
+}
+
+class PromptCacheCheckpoint {
+	constructor(
+		public readonly part: Raw.ChatCompletionContentPartCacheCheckpoint,
+		public readonly childIndex: number
+	) {}
+
+	public toJSON() {
+		return undefined;
+	}
+
+	public materialize(parent: MaterializedChatMessage | GenericMaterializedContainer) {
+		return new MaterializedChatMessageCheckpoint(parent, this.part);
 	}
 }
 

--- a/src/base/promptRenderer.ts
+++ b/src/base/promptRenderer.ts
@@ -10,7 +10,7 @@ import {
 	GenericMaterializedContainer,
 	LineBreakBefore,
 	MaterializedChatMessage,
-	MaterializedChatMessageCheckpoint,
+	MaterializedChatMessageBreakpoint,
 	MaterializedChatMessageImage,
 	MaterializedChatMessageTextChunk,
 } from './materialized';
@@ -616,23 +616,23 @@ export class PromptRenderer<P extends BasePromptElementProps> {
 				return this._handleIntrinsicIgnoredFiles(node, props, children);
 			case 'elementJSON':
 				return this._handleIntrinsicElementJSON(node, props.data);
-			case 'cacheCheckpoint':
-				return this._handleIntrinsicCacheCheckpoint(node, props, children, sortIndex);
+			case 'cacheBreakpoint':
+				return this._handleIntrinsicCacheBreakpoint(node, props, children, sortIndex);
 		}
 		throw new Error(`Unknown intrinsic element ${name}!`);
 	}
 
-	private _handleIntrinsicCacheCheckpoint(
+	private _handleIntrinsicCacheBreakpoint(
 		node: PromptTreeElement,
 		props: any,
 		children: ProcessedPromptPiece[],
 		sortIndex?: number
 	) {
 		if (children.length > 0) {
-			throw new Error(`<cacheCheckpoint /> must not have children!`);
+			throw new Error(`<cacheBreakpoint /> must not have children!`);
 		}
 
-		node.addCacheCheckpoint(props, sortIndex);
+		node.addCacheBreakpoint(props, sortIndex);
 	}
 
 	private _handleIntrinsicMeta(
@@ -863,7 +863,7 @@ type ProcessedPromptPiece =
 	| IntrinsicPromptPiece<any>
 	| ExtrinsicPromptPiece<any, any>;
 
-type PromptNode = PromptTreeElement | PromptText | PromptCacheCheckpoint;
+type PromptNode = PromptTreeElement | PromptText | PromptCacheBreakpoint;
 type LeafPromptNode = PromptText;
 
 /**
@@ -1111,14 +1111,14 @@ class PromptTreeElement {
 		this._metadata.push(metadata);
 	}
 
-	public addCacheCheckpoint(checkpoint: { type: string }, sortIndex = this._children.length): void {
+	public addCacheBreakpoint(breakpoint: { type: string }, sortIndex = this._children.length): void {
 		if (!(this._obj instanceof BaseChatMessage)) {
-			throw new Error('Cache checkpoints may only be direct children of chat messages');
+			throw new Error('Cache breakpoints may only be direct children of chat messages');
 		}
 
 		this._children.push(
-			new PromptCacheCheckpoint(
-				{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: checkpoint.type },
+			new PromptCacheBreakpoint(
+				{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: breakpoint.type },
 				sortIndex
 			)
 		);
@@ -1134,9 +1134,9 @@ class PromptTreeElement {
 	}
 }
 
-class PromptCacheCheckpoint {
+class PromptCacheBreakpoint {
 	constructor(
-		public readonly part: Raw.ChatCompletionContentPartCacheCheckpoint,
+		public readonly part: Raw.ChatCompletionContentPartCacheBreakpoint,
 		public readonly childIndex: number
 	) {}
 
@@ -1145,7 +1145,7 @@ class PromptCacheCheckpoint {
 	}
 
 	public materialize(parent: MaterializedChatMessage | GenericMaterializedContainer) {
-		return new MaterializedChatMessageCheckpoint(parent, this.part);
+		return new MaterializedChatMessageBreakpoint(parent, this.part);
 	}
 }
 

--- a/src/base/test/renderer.test.tsx
+++ b/src/base/test/renderer.test.tsx
@@ -2967,7 +2967,7 @@ suite('PromptRenderer', () => {
 				Infinity,
 				<UserMessage>
 					Hello
-					<cacheCheckpoint type="ephemeral" />
+					<cacheBreakpoint type="ephemeral" />
 					World
 				</UserMessage>
 			);
@@ -2976,7 +2976,7 @@ suite('PromptRenderer', () => {
 					role: Raw.ChatRole.User,
 					content: [
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' },
-						{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: 'ephemeral' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'World' },
 					],
 				},
@@ -2989,12 +2989,12 @@ suite('PromptRenderer', () => {
 				<>
 					<UserMessage>
 						Hello
-						<cacheCheckpoint type="ephemeral" />
+						<cacheBreakpoint type="ephemeral" />
 						World
 					</UserMessage>
 					<UserMessage>
 						Another
-						<cacheCheckpoint type="persistent" />
+						<cacheBreakpoint type="persistent" />
 						Message
 					</UserMessage>
 				</>
@@ -3004,7 +3004,7 @@ suite('PromptRenderer', () => {
 					role: Raw.ChatRole.User,
 					content: [
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Hello' },
-						{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: 'ephemeral' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'World' },
 					],
 				},
@@ -3012,31 +3012,31 @@ suite('PromptRenderer', () => {
 					role: Raw.ChatRole.User,
 					content: [
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Another' },
-						{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: 'persistent' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'persistent' },
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Message' },
 					],
 				},
 			]);
 		});
 
-		test('content before last checkpoint is never pruned', async () => {
+		test('content before last breakpoint is never pruned', async () => {
 			const res1 = await renderFragmentWithMaxPromptTokens(
 				10, // small budget
 				<UserMessage>
 					<TextChunk priority={1}>Lorem</TextChunk>
 					<TextChunk priority={2}>Ipsum</TextChunk>
-					<cacheCheckpoint type="ephemeral" />
+					<cacheBreakpoint type="ephemeral" />
 					<TextChunk priority={3}>Dolor</TextChunk>
 					<TextChunk priority={4}>Sit</TextChunk>
 				</UserMessage>
 			);
-			// Only C/D may be pruned, A/B and checkpoint must remain
+			// Only C/D may be pruned, A/B and breakpoint must remain
 			assert.deepStrictEqual(res1.messages, [
 				{
 					role: Raw.ChatRole.User,
 					content: [
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Lorem\nIpsum' },
-						{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: 'ephemeral' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Sit' },
 					],
 				},
@@ -3047,32 +3047,32 @@ suite('PromptRenderer', () => {
 				<UserMessage>
 					<TextChunk priority={1}>Lorem</TextChunk>
 					<TextChunk priority={2}>Ipsum</TextChunk>
-					<cacheCheckpoint type="ephemeral" />
+					<cacheBreakpoint type="ephemeral" />
 					<TextChunk priority={3}>Dolor</TextChunk>
 					<TextChunk priority={4}>Sit</TextChunk>
 				</UserMessage>
 			);
-			// Only C/D may be pruned, A/B and checkpoint must remain
+			// Only C/D may be pruned, A/B and breakpoint must remain
 			assert.deepStrictEqual(res2.messages, [
 				{
 					role: Raw.ChatRole.User,
 					content: [
 						{ type: Raw.ChatCompletionContentPartKind.Text, text: 'Lorem\nIpsum' },
-						{ type: Raw.ChatCompletionContentPartKind.CacheCheckpoint, cacheType: 'ephemeral' },
+						{ type: Raw.ChatCompletionContentPartKind.CacheBreakpoint, cacheType: 'ephemeral' },
 					],
 				},
 			]);
 		});
 
-		test('throws if message cannot be brought within budget after last checkpoint', async () => {
+		test('throws if message cannot be brought within budget after last breakpoint', async () => {
 			let error: any = undefined;
 			try {
 				await renderFragmentWithMaxPromptTokens(
-					1, // too small for even content before checkpoint
+					1, // too small for even content before breakpoint
 					<UserMessage>
 						<TextChunk priority={1}>A</TextChunk>
 						<TextChunk priority={2}>B</TextChunk>
-						<cacheCheckpoint type="ephemeral" />
+						<cacheBreakpoint type="ephemeral" />
 						<TextChunk priority={3}>C</TextChunk>
 					</UserMessage>
 				);

--- a/src/base/tsx-globals.ts
+++ b/src/base/tsx-globals.ts
@@ -52,13 +52,13 @@ declare global {
 			};
 
 			/**
-			 * Adds a 'cache checkpoint' to the output. This is exclusively valid
+			 * Adds a 'cache breakpoint' to the output. This is exclusively valid
 			 * as a direct child of message types (UserMessage, SystemMessage, etc.)
 			 */
-			cacheCheckpoint: {
+			cacheBreakpoint: {
 				/** Optional implementation-specific cache type */
 				type?: string;
-			}
+			};
 		}
 	}
 }

--- a/src/base/tsx-globals.ts
+++ b/src/base/tsx-globals.ts
@@ -50,6 +50,15 @@ declare global {
 			elementJSON: {
 				data: PromptElementJSON;
 			};
+
+			/**
+			 * Adds a 'cache checkpoint' to the output. This is exclusively valid
+			 * as a direct child of message types (UserMessage, SystemMessage, etc.)
+			 */
+			cacheCheckpoint: {
+				/** Optional implementation-specific cache type */
+				type?: string;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Cachepoints can be added to the output by adding `<cacheCheckpoint />`,
and this appears in 'raw' style output. TSX will also _not_ prune
anything before the last checkpoint: it's up to the consumer to make
sure cached content is stable. However, consumers can still use
`<TokenLimit />` in cached data.

Also makes a little adjustment to token counting to account for message
object overhead. I don't think this was a bug hit in the real world,
but I hit it in unit tests where removed content was undercounted
because objects were removed from the message output.