### PR TITLE
feat: include current messages when throwing budget exceeded error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.4.0-alpha.4",
+	"version": "0.4.0-alpha.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@vscode/prompt-tsx",
-			"version": "0.4.0-alpha.4",
+			"version": "0.4.0-alpha.5",
 			"license": "MIT",
 			"devDependencies": {
 				"@microsoft/tiktokenizer": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vscode/prompt-tsx",
-	"version": "0.4.0-alpha.4",
+	"version": "0.4.0-alpha.5",
 	"description": "Declare LLM prompts with TSX",
 	"main": "./dist/base/index.js",
 	"types": "./dist/base/index.d.ts",

--- a/src/base/materialized.ts
+++ b/src/base/materialized.ts
@@ -698,6 +698,7 @@ function removeLowestPriorityChild(node: ContainerType, removed: MaterializedNod
 /** Thrown when the TSX budget is exceeded and we can't remove elements to reduce it. */
 export class BudgetExceededError extends Error {
 	public metadata!: MetadataMap;
+	public messages!: readonly Raw.ChatMessage[];
 
 	constructor(node: ContainerType) {
 		let path = [node];

--- a/src/base/promptRenderer.ts
+++ b/src/base/promptRenderer.ts
@@ -480,6 +480,7 @@ export class PromptRenderer<P extends BasePromptElementProps, M extends OutputMo
 	 */
 	private async _getFinalElementTree(tokenBudget: number, token: CancellationToken | undefined) {
 		const root = this._root.materialize() as GenericMaterializedContainer;
+		const originalMessages = [...root.toChatMessages()];
 		const allMetadata = [...root.allMetadata()];
 		const limits = [{ limit: tokenBudget, id: this._root.id }, ...this._tokenLimits];
 		let removed = 0;
@@ -532,6 +533,7 @@ export class PromptRenderer<P extends BasePromptElementProps, M extends OutputMo
 			} catch (e) {
 				if (e instanceof BudgetExceededError) {
 					e.metadata = MetadataMap.from([...root.allMetadata()]);
+					e.messages = originalMessages;
 				}
 				throw e;
 			}


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode-copilot/issues/17330